### PR TITLE
`-e` to generate `main` function to turn Lua code into an executable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,38 @@ The performance gains depend on the kind of program being run. For numerical ben
 # Compilation and instalation
 
 This is a modified version of the Lua interpreter so the process is the same you would use for compiling Lua. For full instructions, consult the doc/readme.html.
-
-    make linux -j4
-
+```bash
+make linux -j4
+```
 # Usage
 
 Our compiler generates a `.c` file with a `luaopen_` function. You can compile that into a `.so` module and then require it from Lua. The compilation is the same as any other extension module, except that you need to pass the path to the LuaAOT headers.
-
-    ./src/luaot test.lua -o testcompiled.c
-    gcc -shared -fPIC -O2 -I./src testcompiled.c -o testcompiled.so
-    ./src/lua -l testcompiled
-
+```bash
+./src/luaot test.lua -o testcompiled.c
+gcc -shared -fPIC -O2 -I./src testcompiled.c -o testcompiled.so
+./src/lua -l testcompiled
+```
 Be careful about the name of the generated file. If it has the same name as the original Lua file, the `require` may prioritize the Lua file instead of the compiled on. We also recommend compiling with optimizations, at least -O2.
 
+## Options
+### `-o`
+`-o` is for the output file like:
+```bash
+./src/luaot test.lua -o testcompiled.c # Compile test.lua to testcompiled.c
+```
+### `-m`
+`-m` is for what the name of luaopen function should be in the compiled file, by default it is `luaopen_<FILENAME>`.
+
+Example:
+```bash
+./src/luaot test.lua -o testcompiled.c -m luaopen_testfile # Compile test.lua to testcompiled.c with `luaopen_testfile` as the luaopen function
+```
+### `-e` 
+`-e` just tells the compiler to add a `main` symbol/function so the file can be quickly compiled to an executable like:
+```bash
+./src/luaot test.lua -o testcompiled.c -e # Compile test.lua to testcompiled.c and add a main func for compiling to executables
+gcc -o testexec testcompiled.c -llua5.4 -I/src # Compile testcompiled to an executable that will run the lua code
+```
 # Experiments
 
 If you are interested in reproducing the experiments from our paper, please consult the documentation in the `experiments` and `scripts` directory. Note that you must be inside the experiments directory when you run the scripts:

--- a/src/luaot.c
+++ b/src/luaot.c
@@ -198,6 +198,7 @@ int main(int argc, char **argv)
       println(" }");
       println(" lua_setglobal(L, \"arg\");");
       println(" AOT_LUAOPEN_NAME(L);");
+      println(" return 0;");
       println("}");
     }
 

--- a/src/luaot.c
+++ b/src/luaot.c
@@ -190,6 +190,13 @@ int main(int argc, char **argv)
       println("int main(int argc, char *argv[]) {");
       println(" lua_State *L = luaL_newstate();");
       println(" luaL_openlibs(L);");
+      println(" int i;");
+      println(" lua_createtable(L, argc + 1, 0);");
+      println(" for (i = 0; i < argc; i++) {");
+      println("   lua_pushstring(L, argv[i]);");
+      println("   lua_rawseti(L, -2, i);");
+      println(" }");
+      println(" lua_setglobal(L, \"arg\");");
       println(" AOT_LUAOPEN_NAME(L);");
       println("}");
     }

--- a/src/luaot.c
+++ b/src/luaot.c
@@ -39,10 +39,18 @@ static FILE * output_file = NULL;
 static int nfunctions = 0;
 static TString **tmname;
 
+int executable = 0;
 static
 void usage()
 {
-    fprintf(stderr, "usage: %s input.lua -o output.c\n", program_name);
+    fprintf(stderr,
+          "usage: %s [options] [filename]"
+          "Available options are:"
+          "  -o name  output to file 'name'"
+          "  -m name  generate code with `name` function as main function"
+          "  -s       use  switches instead of gotos in generated code"
+          "  -e       add a main symbol for executables\n",
+          program_name);
 }
 
 static
@@ -100,6 +108,8 @@ static void doargs(int argc, char **argv)
                 i++;
                 if (i >= argc) { fatal_error("missing argument for -m"); }
                 module_name = argv[i];
+            } else if (0 == strcmp(arg, "-e")) {
+                executable = 1;
             } else if (0 == strcmp(arg, "-o")) {
                 i++;
                 if (i >= argc) { fatal_error("missing argument for -o"); }
@@ -176,6 +186,13 @@ int main(int argc, char **argv)
     #elif defined(LUAOT_USE_SWITCHES)
     println("#include \"trampoline_footer.c\"");
     #endif
+    if (executable) {
+      println("int main(int argc, char *argv[]) {");
+      println(" lua_State *L = luaL_newstate();");
+      println(" luaL_openlibs(L);");
+      println(" AOT_LUAOPEN_NAME(L);");
+      println("}");
+    }
 
 }
 


### PR DESCRIPTION
This modification adds a `-e` arg and when it is used a `main` function will be added to the end of the file for compiling to executables. The `main` function creates a new state, opens libraries, and runs the luaopen_x.

## Known issues
- `arg` variable will not be filled out (ADDED)
## Usage
- `luaot myfile.lua -o myfile.c -e`
- `gcc -o myexec myfile.c -llua5.4`