### PR TITLE
Add `-w` for GUI programs on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Example:
 ./src/luaot test.lua -o testcompiled.c -e # Compile test.lua to testcompiled.c and add a main func for compiling to executables
 gcc -o testexec testcompiled.c src/liblua.a -I./src -lm # Compile testcompiled to an executable that will run the lua code
 ```
+### `-w`
+`-w` also enables `-e` but furthermore adds a `WinMain` function, so you can link your lua program with the Windows subsystem and not have a console window pop up when you run it.
+```bash
+./src/luaot test.lua -o testcompiled.c -w # Compile test.lua to testcompiled.c and add a WinMain func for compiling to executables
+gcc -o testexec.exe testcompiled.c src/liblua.a -I./src -mwindows # Compile testcompiled to an executable that will run the lua code without a console window
+```
 # Experiments
 
 If you are interested in reproducing the experiments from our paper, please consult the documentation in the `experiments` and `scripts` directory. Note that you must be inside the experiments directory when you run the scripts:

--- a/src/luaot.c
+++ b/src/luaot.c
@@ -40,6 +40,8 @@ static int nfunctions = 0;
 static TString **tmname;
 
 int executable = 0;
+int use_winmain = 0;
+
 static
 void usage()
 {
@@ -49,7 +51,8 @@ void usage()
           "  -o name            output to file 'name'\n"
           "  -m name            generate code with `name` function as main function\n"
           "  -s                 use  switches instead of gotos in generated code\n"
-          "  -e                 add a main symbol for executables\n",
+          "  -e                 add a main symbol for executables\n"
+          "  -w                 add a WinMain symbol for consoleless executables on windows\n",
           program_name);
 }
 
@@ -110,6 +113,9 @@ static void doargs(int argc, char **argv)
                 module_name = argv[i];
             } else if (0 == strcmp(arg, "-e")) {
                 executable = 1;
+            } else if (0 == strcmp(arg, "-w")) {
+                executable = 1;
+                use_winmain = 1;
             } else if (0 == strcmp(arg, "-o")) {
                 i++;
                 if (i >= argc) { fatal_error("missing argument for -o"); }
@@ -209,6 +215,17 @@ int main(int argc, char **argv)
       println("lua_close(L);");
       println(" return 0;");
       println("}");
+
+      if (use_winmain) {
+        printnl();
+        printnl();
+        println("#ifdef _WIN32");
+        println("#include <windows.h>");
+        println("int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {");
+        println("  return main(__argc, __argv);");
+        println("}");
+        println("#endif");
+      }
     }
 
     return 0;


### PR DESCRIPTION
On windows, if `WinMain` isn't defined and you link with `-mwindows` it is awkward to create GUI applications because a console window pops up, this PR adds the `-w` flag which will make a `WinMain` to fix that